### PR TITLE
Fix systemui fc

### DIFF
--- a/packages/SystemUI/res/values/tesla_colors.xml
+++ b/packages/SystemUI/res/values/tesla_colors.xml
@@ -24,9 +24,9 @@
     <color name="floating_action_button_icon_color">#ffffff</color>
 
     <!-- QS battery % text color -->
-    <color name="qs_battery_text_color">?android:attr/colorAccent</color>
+    <color name="qs_battery_text_color">#ff80cbc4</color>
     <!-- QS battery graph text color -->
     <color name="qs_battery_graph_text_color">#66FFFFFF</color>
     <!-- QS battery accent color -->
-    <color name="qs_battery_accent">?android:attr/colorAccent</color>
+    <color name="qs_battery_accent">#ff80cbc4</color>
 </resources>


### PR DESCRIPTION
- Some color values were causing the fc when clicking battery icon is qs, change them to match the original commit here: http://review.projektsubstratum.com/#/c/64/2/packages/SystemUI/res/values/projekt_colors.xml